### PR TITLE
update the entry points for config_manager

### DIFF
--- a/includes/init.yaml
+++ b/includes/init.yaml
@@ -11,4 +11,4 @@
 - name: validate ansible_network_provider is defined
   fail:
     msg: "missing required setting: ansible_network_provider"
-  when: ansible_network_os is undefined
+  when: ansible_network_provider is undefined

--- a/includes/init.yaml
+++ b/includes/init.yaml
@@ -1,0 +1,14 @@
+---
+- name: set role basic facts
+  set_fact:
+    ansible_network_config_manager_path: "{{ role_path }}"
+    ansible_network_config_manager_version: "devel"
+
+- name: display the role version to stdout
+  debug:
+    msg: "ansible_network.config_manager version is {{ ansible_network_config_manager_version }}"
+
+- name: validate ansible_network_provider is defined
+  fail:
+    msg: "missing required setting: ansible_network_provider"
+  when: ansible_network_os is undefined

--- a/meta/load_config_spec.yaml
+++ b/meta/load_config_spec.yaml
@@ -13,6 +13,15 @@ argument_spec:
         argument should be a string value.  It will be based to the provider
         for loading.  This argument is mutually exclusive with `config_file`
 
+  ansible_network_provider:
+    description:
+      - This value is used to determine the correct role to implement the
+        load_config function.  The network device provider role is responsible
+        for performing the actual implementation of the load_config function.
+        The specified role must be installed and accesible via the configured
+        ansible_role_path setting.
+    required: True
+
 mutually_exclusive:
   - ['config_file', 'config_text']
 

--- a/meta/provider_spec.yaml
+++ b/meta/provider_spec.yaml
@@ -1,0 +1,10 @@
+---
+argument_spec:
+  ansible_network_provider:
+    description:
+      - This value is used to determine the correct role to implement the
+        load_config function.  The network device provider role is responsible
+        for performing the actual implementation of the load_config function.
+        The specified role must be installed and accesible via the configured
+        ansible_role_path setting.
+    required: True

--- a/meta/template_spec.yaml
+++ b/meta/template_spec.yaml
@@ -1,0 +1,16 @@
+---
+argument_spec:
+  config_manager_vars:
+    description:
+      - The set of variables passed to the provider to be used to generate
+        the device configuration.  This value is required.
+    required: True
+
+  ansible_network_provider:
+    description:
+      - This value is used to determine the correct role to implement the
+        load_config function.  The network device provider role is responsible
+        for performing the actual implementation of the load_config function.
+        The specified role must be installed and accesible via the configured
+        ansible_role_path setting.
+    required: True

--- a/tasks/edit.yaml
+++ b/tasks/edit.yaml
@@ -1,9 +1,9 @@
 ---
 - name: validate role spec
   validate_role_spec:
-    spec: load_config_spec.yaml
+    spec: provider_spec.yaml
 
 - name: invoke network provider
   include_role:
     name: "{{ ansible_network_provider }}"
-    tasks_from: config_manager/load
+    tasks_from: config_manager/edit

--- a/tasks/get.yaml
+++ b/tasks/get.yaml
@@ -1,9 +1,9 @@
 ---
 - name: validate role spec
   validate_role_spec:
-    spec: load_config_spec.yaml
+    spec: provider_spec.yaml
 
 - name: invoke network provider
   include_role:
     name: "{{ ansible_network_provider }}"
-    tasks_from: config_manager/load
+    tasks_from: config_manager/get

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,23 @@
 ---
 # tasks file for ansible-network.config_manager
+#
+- name: initialize function
+  include_tasks: includes/init.yaml
+
+- name: set role supported functions
+  set_fact:
+    config_manager_functions:
+      - get
+      - load
+      - edit
+      - save
+      - template
+      - noop
+
+- name: validate the requested function is supported
+  fail:
+    msg: "invalid function specified, expected one of {{ config_manager_functions }}, got {{ function }}"
+  when: function | default('noop') not in config_manager_functions
+
+- name: include function specific tasks and run
+  include_tasks: "{{ function  | default('noop') }}.yaml"

--- a/tasks/noop.yaml
+++ b/tasks/noop.yaml
@@ -1,0 +1,4 @@
+---
+- name: display mesage
+  debug:
+    msg: "role version is {{ ansible_network_eos_version }}"

--- a/tasks/save.yaml
+++ b/tasks/save.yaml
@@ -1,9 +1,9 @@
 ---
 - name: validate role spec
   validate_role_spec:
-    spec: load_config_spec.yaml
+    spec: provider_spec.yaml
 
 - name: invoke network provider
   include_role:
     name: "{{ ansible_network_provider }}"
-    tasks_from: config_manager/load
+    tasks_from: config_manager/save

--- a/tasks/template.yaml
+++ b/tasks/template.yaml
@@ -1,9 +1,9 @@
 ---
 - name: validate role spec
   validate_role_spec:
-    spec: load_config_spec.yaml
+    spec: provider_spec.yaml
 
 - name: invoke network provider
   include_role:
     name: "{{ ansible_network_provider }}"
-    tasks_from: config_manager/load
+    tasks_from: config_manager/template


### PR DESCRIPTION
This change will update the entry points to drop the _config from the
task entry points.  It also adds the main task to map functions to tasks
for direct role execution.