### PR TITLE
remove template from config_manager

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,6 @@
       - load
       - edit
       - save
-      - template
       - noop
 
 - name: validate the requested function is supported

--- a/tasks/template.yaml
+++ b/tasks/template.yaml
@@ -1,9 +1,0 @@
----
-- name: validate role spec
-  validate_role_spec:
-    spec: provider_spec.yaml
-
-- name: invoke network provider
-  include_role:
-    name: "{{ ansible_network_provider }}"
-    tasks_from: config_manager/template


### PR DESCRIPTION
This change removes thes template function from config_manager as it
will not be supported in the upcoming release of the role.