### PR TITLE
add scm support for load function

### DIFF
--- a/meta/load_spec.yaml
+++ b/meta/load_spec.yaml
@@ -13,6 +13,19 @@ argument_spec:
         argument should be a string value.  It will be based to the provider
         for loading.  This argument is mutually exclusive with `config_manager_file`
 
+  config_manager_scm_url:
+    descrption:
+      - Configures a SCM URL to retrieve the host configuration files from.
+        This value will checkout the config file from the SCM system and then
+        search for a valid configuration file that corresponds to the
+        target host based on the value of inventory_hostname_short.
+
+  config_manager_scm_file:
+    description:
+      - This setting overrides the default search path for the configuration
+        filename when using config_manager_scm_url.  The value in for this
+        argument should be relative to the root of the SCM checkout.
+
   config_manager_replace:
     descriptiion:
       - This setting indicates whether or not the provided configuration file
@@ -34,4 +47,4 @@ mutually_exclusive:
   - ['config_manager_file', 'config_manager_text']
 
 required_one_of:
-  - ['config_manager_file', 'config_manager_text']
+  - ['config_manager_file', 'config_manager_text', 'config_manager_scm_url']

--- a/tasks/load.yaml
+++ b/tasks/load.yaml
@@ -3,6 +3,55 @@
   validate_role_spec:
     spec: load_spec.yaml
 
+# check if host vars are stored in scm and if they are get the latest version
+- name: get host vars from scm
+  block:
+    - name: create temp working directory
+      tempfile:
+        state: directory
+      register: config_manager_working_dir
+      changed_when: false
+
+    - name: checkout scm project
+      git:
+        repo: "{{ config_manager_scm_url }}"
+        dest: "{{ config_manager_working_dir.path }}"
+      changed_when: false
+
+    - name: discover the configuration file path and load it
+      set_fact:
+        config_manager_text: "{{ lookup('file', item) }}"
+      with_first_found:
+        - files:
+            - "{{ inventory_hostname_short }}"
+            - "{{ inventory_hostname_short }}.cfg"
+          paths:
+            - "{{ config_manager_working_dir.path }}/{{ ansible_network_os }}"
+            - "{{ config_manager_working_dir.path }}"
+      when: config_manager_scm_file is undefined
+
+    - name: load the configuration text from config_manager_scm_file
+      set_fact:
+        config_manager_text: "{{ lookup('file', config_manager_scm_file }}"
+      when: config_manager_scm_file is defined
+
+    - name: remove temporary working dir
+      file:
+        path: config_manager_working_dir.path
+        state: absent
+      changed_when: false
+  rescue:
+    - name: remove temporary working dir
+      file:
+        path: "{{ config_manager_working_dir.path }}"
+        state: absent
+      changed_when: false
+
+    - name: fail the host
+      fail:
+        msg: "no configuration file found for host"
+  when: config_manager_scm_url is defined
+
 - name: invoke network provider
   include_role:
     name: "{{ ansible_network_provider }}"


### PR DESCRIPTION
This change adds scm support to allow the role to automatically retrieve
the device configuration from scm. For this change, only git is
supported.