### PR TITLE
various documentation update

### DIFF
--- a/docs/get.md
+++ b/docs/get.md
@@ -8,7 +8,7 @@ accessed via `config_manager.config` fact.
 
 ## How to use this function
 
-The examples below demonstate how to use this function in a playbook.
+The examples below demonstrate how to use this function in a playbook.
 
 ### How to get the device configuration
 
@@ -20,7 +20,7 @@ Below is an example of calling the `get` function from the playbook.
 ```
 ---
 - hosts: network
-
+  gather_facts: false
   roles:
     - name ansible-network.config_manager
       function: get
@@ -32,13 +32,14 @@ each device in the inventory group `network`.
 
 ### How to get the device configuration from tasks
 
-The `get` function can also be inlcudes in the playbook `Tasks:` section and
+The `get` function can also be includes in the playbook `Tasks:` section and
 executed as part of the list of tasks.  Below is an example of how to retrieve
 the configuration using tasks.
 
 ```
 ---
 - hosts: network
+  gather_facts: false
 
   tasks:
     - name: get active configuration from device
@@ -46,13 +47,13 @@ the configuration using tasks.
         name: ansible-network.config_manager
         tasks_from: get
 
-    - name: display the device configation to stdout
+    - name: display the device configuration to stdout
       debug:
         var: config_manager.config.split('\n')
 ```
 
 The example playbook above will retrieve the current running configuration and
-then display the configration contents to stdout.
+then display the configuration contents to stdout.
 
 ## Arguments
 

--- a/docs/load.md
+++ b/docs/load.md
@@ -15,7 +15,7 @@ The examples below demonstate how to use this function in a playbook.
 ## How to load and merge a configuration
 
 Loading a configuration onto a target device is fairly simple and
-straightforward.  By default, the `load` function will merge the contents of 
+straightforward.  By default, the `load` function will merge the contents of
 the provided configuration file with the configuration running on
 the target device.  
 
@@ -23,7 +23,8 @@ Below is an example of how to call the `load` function.
 
 ```
 - hosts: network
-  
+  gather_facts: false
+
   roles:
     - name: ansible-network.config_manager
       function: load
@@ -42,7 +43,8 @@ configuration, set the `config_manager_replace` value to True.
 
 ```
 - hosts: network
-  
+  gather_facts: false
+
   roles:
     - name: ansible-network.config_manager
       function: load

--- a/docs/save.md
+++ b/docs/save.md
@@ -1,7 +1,7 @@
 # Save active configuration to startup
 
 For network platforms that support saving the current active (running)
-configurationt to non-volatile storage, the Config Manager `save` function can
+configuration to non-volatile storage, the Config Manager `save` function can
 be invoked.  This function will issue the save command on the target platform
 regardless of whether or not the active configuration has changed.  
 
@@ -11,13 +11,14 @@ simply return a NOOP.
 ## How to save the active configuration
 
 To save the current active configuration to the startup configuration simply
-invoke the `save` function on the target device.  There are no additional 
-configuration options for this funnction.
+invoke the `save` function on the target device.  There are no additional
+configuration options for this function.
 
 Below is an example of calling the `save_config` function from the playbook.
 
 ```
 - hosts: network
+  gather_facts: false
 
   roles:
     - name ansible-network.arista_eos


### PR DESCRIPTION
adding gather_facts: false to make the examples work out of the box and match our documentation.  Fixing some various spelling mistakes.