### PR TITLE
move the config file load into config_manager

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for ansible-network.config_manager
 #
+config_manager_replace: False

--- a/meta/load_spec.yaml
+++ b/meta/load_spec.yaml
@@ -44,7 +44,7 @@ argument_spec:
     required: True
 
 mutually_exclusive:
-  - ['config_manager_file', 'config_manager_text']
+  - ['config_manager_file', 'config_manager_text', 'config_manager_scm_url']
 
 required_one_of:
   - ['config_manager_file', 'config_manager_text', 'config_manager_scm_url']

--- a/tasks/load.yaml
+++ b/tasks/load.yaml
@@ -3,8 +3,10 @@
   validate_role_spec:
     spec: load_spec.yaml
 
-# check if host vars are stored in scm and if they are get the latest version
-- name: get host vars from scm
+# this block will clone the scm provided by config_manager_scm_url and either
+# discover the host configuration file or explicitly load a configuration file
+# defined by config_manager_scm_file.
+- name: retrieve configuration file from scm
   block:
     - name: create temp working directory
       tempfile:
@@ -20,7 +22,7 @@
 
     - name: discover the configuration file path and load it
       set_fact:
-        config_manager_text: "{{ lookup('file', item) }}"
+        config_manager_file: "{{ item }}"
       with_first_found:
         - files:
             - "{{ inventory_hostname_short }}"
@@ -30,9 +32,9 @@
             - "{{ config_manager_working_dir.path }}"
       when: config_manager_scm_file is undefined
 
-    - name: load the configuration text from config_manager_scm_file
+    - name: set the config_manager_file value based on config_manager_scm_file
       set_fact:
-        config_manager_text: "{{ lookup('file', config_manager_scm_file }}"
+        config_manager_file: "{{ config_manager_scm_file }}"
       when: config_manager_scm_file is defined
 
     - name: remove temporary working dir
@@ -51,6 +53,21 @@
       fail:
         msg: "no configuration file found for host"
   when: config_manager_scm_url is defined
+
+# if the configuration is provide via a file by setting config_manager_file
+# either explicitly or disovered via scm, load the configuration contents and
+# hand off config_manager_text to the provider role for implementation.
+- name: load config file contents
+  set_fact:
+    config_manager_text: "{{ lookup('config_template', config_manager_file) | join('\n') }}"
+  when: config_manager_file is defined
+
+# validate at this point that config_manager_text is set othewise fail
+# the host.
+- name: validate config_manager_text is defined
+  fail:
+    msg: "missing required arg: config_manager_text"
+  when: config_manager_text is undefined
 
 - name: invoke network provider
   include_role:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,6 @@
     config_manager_functions:
       - get
       - load
-      - edit
       - save
       - noop
 


### PR DESCRIPTION
This change moves the handling of the config file to the
config_manager/load function.  The load function will now handle off
only config_manager_text to the platform role for implementation.

This change also makes config_manager_text, config_manager_file 
and config_manager_scm_url all mutually exclusive.