### PR TITLE
add templates list as option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.confPath": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.confPath": ""
-}

--- a/meta/load_spec.yaml
+++ b/meta/load_spec.yaml
@@ -6,12 +6,20 @@ argument_spec:
         file containing the device configuration.  This value will be passed
         to the provider and loaded onto the target device.  This argument is
         mutually exclusive with `config_manager_text`.
+  
+  config_manager_templates:
+    description:
+      - Specifies templates to be loaded onto the target device.  This
+        argument should be a list.  It will be passed to the provider
+        for loading.  This argument is mutually exclusive with `config_manager_file`
+        and `config_manager_text`.
 
   config_manager_text:
     description:
       - Specifies the configuration to be loaded onto the target device.  This
         argument should be a string value.  It will be based to the provider
         for loading.  This argument is mutually exclusive with `config_manager_file`
+        and `config_manager_templates`.
 
   config_manager_scm_url:
     descrption:
@@ -44,7 +52,7 @@ argument_spec:
     required: True
 
 mutually_exclusive:
-  - ['config_manager_file', 'config_manager_text', 'config_manager_scm_url']
+  - ['config_manager_file', 'config_manager_templates', 'config_manager_text', 'config_manager_scm_url']
 
 required_one_of:
-  - ['config_manager_file', 'config_manager_text', 'config_manager_scm_url']
+  - ['config_manager_file', 'config_manager_templates', 'config_manager_text', 'config_manager_scm_url']

--- a/tasks/load.yaml
+++ b/tasks/load.yaml
@@ -61,12 +61,12 @@
     config_manager_text: "{{ lookup('config_template', config_manager_file) | join('\n') }}"
   when: config_manager_file is defined
 
-# validate at this point that config_manager_text is set othewise fail
-# the host.
-- name: validate config_manager_text is defined
+# validate at this point that either config_manager_text or config_manager_templates is set,
+# othewise fail the host.
+- name: validate config_manager_text or config_manager_templates is defined
   fail:
-    msg: "missing required arg: config_manager_text"
-  when: config_manager_text is undefined
+    msg: "missing required arg: config_manager_text or config_manager_templates"
+  when: config_manager_text is undefined and config_manager_templates is undefined
 
 - name: invoke network provider
   include_role:


### PR DESCRIPTION
Adding config_manager_templates as an option for this role so we can pass a list of names of templates to apply, there is a template, config_sections.j2 that combines the templates so we can easily apply whichever templates we want with this role.   I'm updating cisco_ios to accommodate this also.